### PR TITLE
Implement announcements (static messages / "pinned" "queue entries")

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -145,6 +145,105 @@ authenticate itself:
 | 415          | Request body too big
 |=============================================
 
+GET `/api/v2/announcement`
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+|=============================================
+| Request Content-Type  | none
+| Response Content-Type | `application/json`
+| Authentication        | no
+|=============================================
+
+The endpoint can be used to query the current announcement
+text. If one exists, the following response format is used:
+
+---------------------------
+{
+  "announcement": "some announcement text"
+}
+---------------------------
+
+If however no announcement text has been set (or it has been
+deleted), the response looks like this and is returned with
+a response status of 404:
+
+---------------------------
+{
+  "announcement": null
+}
+---------------------------
+
+|=============================================
+| HTTP Status  | Meaning
+| 200          | Success
+| 404          | No announcement text is set
+|=============================================
+
+PUT `/api/v2/announcement`
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+|=============================================
+| Request Content-Type  | `application/x-www-form-urlencoded`
+| Response Content-Type | `application/json`
+| Authentication        | yes (see below)
+|=============================================
+
+This endpoint allows you to set the announcement
+text which will be displayed on the panel (if
+enabled) during times when the queue is empty.
+
+Since the API call overwrites previous content,
+it requires authentication additionally. Any
+call to this endpoint must send a form with
+the following fields:
+
+|=============================================
+| `text`  | text to be added to the queue
+| `token` | API token of the application
+|=============================================
+
+The response contains the announcement in the
+same format as the `GET` variant of this endpoint,
+except it's guaranteed to never be `null`:
+
+----------------------
+{
+  "announcement": "new announcement"
+}
+----------------------
+
+|=============================================
+| HTTP Status  | Meaning
+| 200          | Success, announcement set
+| 400          | Illegal method or malformed request
+| 415          | Request body too big or text field longer allowed (usually 512 bytes)
+|=============================================
+
+DELETE `/api/v2/announcement`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+|=============================================
+| Request Content-Type  | `application/x-www-form-urlencoded`
+| Response Content-Type | none
+| Authentication        | yes (see below)
+|=============================================
+
+This endpoint can be used to delete the announcement text.
+The request should send a form with the following fields
+as request body in order to authenticate itself:
+
+|=============================================
+| `token` | API token of the application
+|=============================================
+
+|=============================================
+| HTTP Status  | Meaning
+| 204          | Success, queue entry deleted
+| 400          | Illegal method or malformed request
+| 401          | Unauthorized API token
+| 415          | Request body too big
+|=============================================
+
 API `v1`
 ~~~~~~~
 

--- a/README.adoc
+++ b/README.adoc
@@ -159,9 +159,16 @@ text. If one exists, the following response format is used:
 
 ---------------------------
 {
-  "announcement": "some announcement text"
+  "announcement": "some announcement text",
+  "expiry_utc": 1607383640
 }
 ---------------------------
+
+`expiriy_utc` describes the expiry time of the announcement in
+seconds since 1970-01-01 00:00 UTC. Note the expiry time doesn't
+necessarily need to be checked manually as the endpoint guarantees
+to never return an expired announcement. If the announcement
+never expires, `expiry_utc` is `null`.
 
 If however no announcement text has been set (or it has been
 deleted), the response looks like this and is returned with
@@ -169,7 +176,8 @@ a response status of 404:
 
 ---------------------------
 {
-  "announcement": null
+  "announcement": null,
+  "expiry_utc": null
 }
 ---------------------------
 
@@ -198,8 +206,9 @@ call to this endpoint must send a form with
 the following fields:
 
 |=============================================
-| `text`  | text to be added to the queue
-| `token` | API token of the application
+| `text`       | text to be added to the queue
+| `token`      | API token of the application
+| `expiry_utc` | Optional: time in seconds since the unix epoch the announcement expires (is deleted) at
 |=============================================
 
 The response contains the announcement in the
@@ -208,9 +217,13 @@ except it's guaranteed to never be `null`:
 
 ----------------------
 {
-  "announcement": "new announcement"
+  "announcement": "new announcement",
+  "expiry_utc": null
 }
 ----------------------
+
+`expiry_utc` will of course hold a timestamp if
+one was given in the request.
 
 |=============================================
 | HTTP Status  | Meaning

--- a/clients/py/flipdot_gschichtler/__init__.py
+++ b/clients/py/flipdot_gschichtler/__init__.py
@@ -40,7 +40,7 @@ class FlipdotGschichtlerClient():
 
     def delete(self, queue_id):
         if self.api_token is None:
-            raise Exception('missing api token')
+            raise FlipdotGschichtlerNoToken
 
         endpoint = '/api/v2/queue/' + str(queue_id)
         r = requests.delete(self.base_url + endpoint, data = { 'token': self.api_token })
@@ -68,3 +68,39 @@ class FlipdotGschichtlerClient():
         else:
             message = self.__get_error_message(r)
             raise FlipdotGschichtlerClient(endpoint, r.status_code, message)
+
+    def announcement(self):
+        endpoint = '/api/v2/announcement'
+        r = requests.get(self.base_url + endpoint)
+
+        if r.status_code == 200:
+            return r.json()['announcement']
+        elif r.status_code == 404:
+            # no / empty announcement
+            assert 'announcement' in r.json()
+            return None
+        else:
+            message = self.__get_error_message(r)
+            raise FlipdotGschichtlerError(endpoint, r.status_code, message)
+
+    def set_announcement(self, text):
+        if self.api_token == None:
+            raise FlipdotGschichtlerNoToken
+
+        endpoint = '/api/v2/announcement'
+        r = requests.put(self.base_url + endpoint, data = { 'text': text, 'token': self.api_token })
+
+        if r.status_code != 200:
+            message = self.__get_error_message(r)
+            raise FlipdotGschichtlerError(endpoint, r.status_code, message)
+
+    def delete_announcement(self):
+        if self.api_token == None:
+            raise FlipdotGschichtlerNoToken
+
+        endpoint = '/api/v2/announcement'
+        r = requests.delete(self.base_url + endpoint, data = { 'token': self.api_token })
+
+        if r.status_code != 204:
+            message = self.__get_error_message(r)
+            raise FlipdotGschichtlerError(endpoint, r.status_code, message)

--- a/warteraum/announcement.c
+++ b/warteraum/announcement.c
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "announcement.h"
+
+void announcement_new(struct warteraum_announcement *announcement) {
+  announcement->text.len = -1;
+  announcement->text.buf = NULL;
+  announcement->announcement_expires = 0;
+  announcement->announcement_expiry = 0;
+}
+
+void announcement_delete(struct warteraum_announcement *announcement) {
+  if(announcement->text.buf != NULL) {
+    free((void *) announcement->text.buf);
+  }
+  announcement->text.len = -1;
+  announcement->text.buf = NULL;
+
+  announcement->announcement_expires = 0;
+  announcement->announcement_expiry = 0;
+}
+
+bool announcement_set(struct warteraum_announcement *announcement, struct http_string_s s) {
+  announcement_delete(announcement);
+
+  char *new_buf = malloc(s.len);
+
+  if(new_buf == NULL) {
+    return false;
+  }
+
+  memcpy(new_buf, s.buf, s.len);
+
+  announcement->text.len = s.len;
+  announcement->text.buf = new_buf;
+
+  announcement->announcement_expires = 0;
+  announcement->announcement_expiry = 0;
+
+  return true;
+}
+
+bool announcement_set_expiring(struct warteraum_announcement *announcement, struct http_string_s s, time_t t) {
+  if(!announcement_set(announcement, s)) {
+    return false;
+  }
+
+  announcement->announcement_expires = 1;
+  announcement->announcement_expiry = t;
+
+  return true;
+}
+
+bool announcement_expired(struct warteraum_announcement announcement) {
+  if(announcement.announcement_expires) {
+    time_t now = time(NULL);
+    return now > announcement.announcement_expiry;
+  } else {
+    return false;
+  }
+}

--- a/warteraum/announcement.h
+++ b/warteraum/announcement.h
@@ -1,0 +1,25 @@
+#ifndef WARTERAUM_ANNOUNCEMENT_H
+#define WARTERAUM_ANNOUNCEMENT_H
+
+#include "../third_party/httpserver.h/httpserver.h"
+
+#include <stdbool.h>
+#include <time.h>
+
+struct warteraum_announcement {
+  struct http_string_s text;
+
+  bool   announcement_expires;
+  time_t announcement_expiry;
+};
+
+void announcement_new(struct warteraum_announcement *);
+
+void announcement_delete(struct warteraum_announcement *);
+
+bool announcement_set(struct warteraum_announcement *, struct http_string_s);
+
+bool announcement_set_expiring(struct warteraum_announcement *, struct http_string_s, time_t);
+
+bool announcement_expired(struct warteraum_announcement);
+#endif

--- a/warteraum/default.o.do
+++ b/warteraum/default.o.do
@@ -24,6 +24,12 @@ case "$2" in
   hashtoken)
     redo-ifchange scrypt.h
     ;;
+  announcement)
+    redo-ifchange ../third_party/httpserver.h/httpserver.h
+    ;;
+  http_string)
+    redo-ifchange ../third_party/httpserver.h/httpserver.h
+    ;;
 esac
 
 $CC $CFLAGS -o "$3" -c "$2.c"

--- a/warteraum/http_string.c
+++ b/warteraum/http_string.c
@@ -1,0 +1,29 @@
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "http_string.h"
+
+unsigned long long http_string_to_uint(struct http_string_s s) {
+  char *zero_terminated = malloc(s.len + 1);
+  char *end = NULL;
+
+  if(zero_terminated == NULL) {
+    errno = ENOMEM;
+    return ULONG_MAX;
+  }
+
+  memcpy(zero_terminated, s.buf, s.len);
+  zero_terminated[s.len] = '\0';
+
+  unsigned long long int l = strtoull(zero_terminated, &end, 10);
+
+  if(*end != '\0') {
+    errno = EINVAL;
+  }
+
+  free(zero_terminated);
+
+  return l;
+}

--- a/warteraum/http_string.h
+++ b/warteraum/http_string.h
@@ -3,6 +3,8 @@
 
 #include <string.h>
 
+#include "../third_party/httpserver.h/httpserver.h"
+
 #define STATIC_HTTP_STRING(s) \
   { s, sizeof(s) - 1 }
 
@@ -11,5 +13,7 @@
 
 #define HTTP_STRING_IS(a, s) \
   (a.len == sizeof(s) - 1 && strncmp(a.buf, s, a.len) == 0)
+
+unsigned long long http_string_to_uint(struct http_string_s);
 
 #endif

--- a/warteraum/test/run
+++ b/warteraum/test/run
@@ -44,7 +44,7 @@ if command -v pytest > /dev/null; then
 
   sleep 3
 
-  pytest ./test_integration.py
+  pytest -v ./test_integration.py
 
   kill $pid
 

--- a/warteraum/test/test_integration.py
+++ b/warteraum/test/test_integration.py
@@ -137,6 +137,28 @@ def test_correct_failure_with_valid_token():
         api.delete(highest_id + 1)
         assert err.status == 404
 
+def test_expected_authentication_failures_announcement():
+    my_announcement = 'announcement works'
+
+    for t in WRONG_TOKENS:
+        tmp_client = FlipdotGschichtlerClient(BASE_URL, api_token = t)
+
+        with pytest.raises(FlipdotGschichtlerError) as exc_info:
+            tmp_client.delete_announcement()
+
+        assert exc_info.value.status == 401
+
+        api.delete_announcement()
+
+        with pytest.raises(FlipdotGschichtlerError) as exc_info:
+            tmp_client.set_announcement(my_announcement)
+
+        assert exc_info.value.status == 401
+
+        api.set_announcement(my_announcement)
+
+        assert tmp_client.announcement() == my_announcement
+
 # queue properties
 
 def test_queue_ascending_ids():

--- a/warteraum/test/test_integration.py
+++ b/warteraum/test/test_integration.py
@@ -51,6 +51,28 @@ def test_queue_404_format():
     assert r.status_code == 404
     assert 'not found' in r.json()['error']
 
+def test_announcement_formats():
+    my_text = 'important news'
+
+    r = requests.delete(BASE_URL + '/api/v2/announcement', data = { 'token' : TOKEN })
+    assert r.status_code == 204
+
+    r1 = requests.get(BASE_URL + '/api/v2/announcement')
+    assert r1.status_code == 404
+    assert r1.json()['announcement'] == None
+
+    r2 = requests.put(BASE_URL + '/api/v2/announcement', data = { 'text' : my_text, 'token' : TOKEN })
+    assert r2.status_code == 200
+    assert r2.json()['announcement'] == my_text
+
+    r3 = requests.get(BASE_URL + '/api/v2/announcement')
+    assert r3.status_code == 200
+    assert r3.json()['announcement'] == my_text
+
+    # check that token is required
+    r4 = requests.put(BASE_URL + '/api/v2/announcement', data = { 'text' : 'oops' })
+    assert r4.status_code == 400
+
 # /api/v2/queue/add input validation and normalization
 
 def test_strip_whitespace():

--- a/warteraum/warteraum.do
+++ b/warteraum/warteraum.do
@@ -1,6 +1,6 @@
 source ./build_config
 redo-ifchange ./build_config
-OBJS="emitjson.o queue.o routing.o form.o main.o"
+OBJS="emitjson.o queue.o routing.o form.o main.o announcement.o http_string.o"
 DEPS="$OBJS ../third_party/httpserver.h/httpserver.h"
 redo-ifchange $DEPS
 


### PR DESCRIPTION
* `PUT /api/v2/announcement`: Set announcement text, requires token
* `DELETE /api/v2/announcement`: Remove announcement text, requires token
* `GET /api/v2/announcement`: View announcement text, unauthenticated