### PR TITLE
chore(warteraum): remove support for v1 API

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,42 +148,7 @@ authenticate itself:
 API `v1`
 ~~~~~~~
 
-GET `/api/v1/queue`
-^^^^^^^^^^^^^^^^^^^
-
-Same as `/api/v2/queue`, since v2 didn't introduce any changes.
-
-POST `/api/v1/queue/add`
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-|=============================================
-| Request Content-Type  | `application/x-www-form-urlencoded`
-| Response Content-Type | `text/html`
-| Authentication        | no
-|=============================================
-
-This is the legacy endpoint to add text to the queue. It enabled
-interacting with it via a `<form>` in the old web app. The form
-sent as part of the request should have the following fields:
-
-|=============================================
-| `text` | text to be added to the queue
-|=============================================
-
-The response format has been changed since the previous implementation.
-I sincerly hope that nobody scraped the resulting page.
-
-|=============================================
-| HTTP Status  | Meaning
-| 200          | Success, text added
-| 400          | Illegal method or malformed request
-| 415          | Request body too big or text field longer allowed (usually 512 bytes)
-|=============================================
-
-DELETE `/api/v1/queue/del/<id>`
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Same as `/api/v2/queue/<id>`, `v2` only changed the endpoint URL.
+Unsupported since version 2.2.0.
 
 Bug Bounty
 ----------
@@ -335,6 +300,12 @@ and only possible with a knowledge of `warteraum` internals.
 
 Changelog
 ---------
+
+2.2.0 (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+* `warteraum`
+** Remove support for the `v1` API completely.
 
 2.1.0
 ~~~~~

--- a/bahnhofshalle/index.html
+++ b/bahnhofshalle/index.html
@@ -22,7 +22,7 @@
     <main>
       <section id="send-new">
         <h2>display your <span id="display-what">text</span> on the flipdot panel</h2>
-        <form id="send-form" action="/api/v1/queue/add" method="post" enctype="application/x-www-form-urlencoded">
+        <form id="send-form" action="/api/v2/queue/add" method="post" enctype="application/x-www-form-urlencoded">
           <div class="input-button">
             <input name="text" id="text" type="text" placeholder="Text">
             <input type="submit" value="Send" id="submit">

--- a/warteraum/GNUmakefile
+++ b/warteraum/GNUmakefile
@@ -26,7 +26,7 @@ warteraum: http_string.o emitjson.o queue.o routing.o form.o auth.o main.o
 hashtoken: hashtoken.o http_string.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
-main.o: main.c queue.h routing.h form.h v1_static.h emitjson.h \
+main.o: main.c queue.h routing.h form.h emitjson.h \
 	auth.h http_string.h $(HTTPSERVER)
 
 form.o: form.c http_string.h $(HTTPSERVER)

--- a/warteraum/v1_static.h
+++ b/warteraum/v1_static.h
@@ -1,5 +1,0 @@
-#define QUEUE_ADD_V1_SUCCESS \
-  "<!doctype html><head lang=\"en\"><meta charset=\"utf-8\"><title>success</title></head><body>your text was added to the queue</body></html>"
-
-#define QUEUE_ADD_V1_FAILURE \
-  "<!doctype html><head lang=\"en\"><meta charset=\"utf-8\"><title>failure</title></head><body>your request resulted in an error</body></html>"


### PR DESCRIPTION
I could not find any evidence anyone has been using this API this year (except some AI companies' crawler bots sending GET requests to the wrong endpoints), so it seems like it's as good a time as any to pull the plug.

The old endpoints now return 410 Gone. bahnhofshalle without JavaScript will now use the v2 API as a fallback, meaning that the user will be shown JSON instead of a (lackluster) HTML page.

Due to the whitespace changes, it is easiest to review this change with `git diff -b`.